### PR TITLE
Added Parsedown to the PEAR Dependency list.

### DIFF
--- a/docs/install.html
+++ b/docs/install.html
@@ -112,6 +112,7 @@
 		<li>pear install Archive_Tar</li>
 		<li>pear install geshi/geshi</li>
 		<li>pear install Text_Diff</li>
+		<li>pear install erusev/Parsedown</li>
 	</ol>
 
 	<p>


### PR DESCRIPTION
Hi,

I have added the parsedown to the PEAR dependency list. But it is not able to fetch it from the default channels. 
I tried adding the parsedown.org channel but i guess there is no PEAR distribution for this Parsedown Library.

Can someone check it out before i merge? Should not take much time??